### PR TITLE
copy requirements.txt before requirements-dev.txt in dockerfile

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add --no-cache linux-headers make gcc musl-dev libxml2-dev libxslt-dev l
 
 WORKDIR /flask/src
 
+COPY ./requirements.txt requirements.txt
 COPY ./requirements-dev.txt requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
-COPY ./requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 USER flask


### PR DESCRIPTION
As requirements-dev.txt contains -r requirements.txt, docker cannot find requirements.txt:

Step 8/16 : RUN pip install --no-cache-dir -r requirements-dev.txt
---> Running in 565be17cef7b
Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
You are using pip version 10.0.1, however version 18.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
ERROR: Service 'sphinx_docs' failed to build: The command '/bin/sh -c pip install --no-cache-dir -r requirements-dev.txt' returned a non-zero code: 1